### PR TITLE
Small fix to prevent error in P2 theme

### DIFF
--- a/post-forking.php
+++ b/post-forking.php
@@ -375,7 +375,7 @@ class Fork {
  	 * @param int $id the post ID
  	 * @return string the modified post title
  	 */
- 	function title_filter( $title, $id = false ) {
+ 	function title_filter( $title, $id = 0 ) {
 
  		if ( get_post_type( $id ) != 'fork' )
  			return $title;


### PR DESCRIPTION
Using the P2 theme I get "Missing argument 2 for Fork::title_filter()" errors on all posts as shown here: http://cl.ly/image/1u280K2j0k0j

This isn't a perfect solution, but it doesn't seem to break anything and it gets rid of the errors. Possibly contributes to #4.

I haven't run this through the unit tests though, as I'm not 100% familiar with getting that going.
