### PR TITLE
Prevent CSRF attacks on post forking and merging

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -54,6 +54,8 @@ class Fork_Admin {
 		if ( !isset( $_GET['fork'] ) )
 			return;
 
+		check_admin_referer( 'post-forking-fork_' . intval( $_GET['fork'] ) );
+
 		$fork = $this->parent->fork( (int) $_GET['fork'] );
 
 		if ( !$fork )
@@ -72,6 +74,8 @@ class Fork_Admin {
 
 		if ( !isset( $_GET['merge'] ) )
 			return;
+
+		check_admin_referer( 'post-forking-merge_' . intval( $_GET['merge'] ) );
 
 		$this->parent->merge->merge( (int) $_GET['merge'] );
 
@@ -161,7 +165,7 @@ class Fork_Admin {
 
 		if ( post_type_supports( get_post_type( $post ), $this->parent->post_type_support ) ) {
 			$label = ( $this->parent->branches->can_branch ( $post ) ) ? __( 'Create branch', 'post-forking' ) : __( 'Fork', 'post-forking' );
-			$actions[] = '<a href="' . admin_url( "?fork={$post->ID}" ) . '">' . $label . '</a>';
+			$actions[] = '<a href="' . wp_nonce_url( admin_url( "?fork={$post->ID}" ), 'post-forking-fork_' . $post->ID ) . '">' . $label . '</a>';
 		}
 
 		if ( Fork::post_type == get_post_type( $post ) ) {
@@ -182,6 +186,8 @@ class Fork_Admin {
 
 		foreach ( array( 'post', 'author', 'action' ) as $var )
 			$$var = ( isset( $_GET[$var] ) ) ? $_GET[$var] : null;
+
+		check_ajax_referer( 'post-forking-' . $action . '_' . $post );
 
 		if ( $action == 'merge' )
 			$result = $this->parent->merge->merge( $post, $author );

--- a/templates/author-post-meta-box.php
+++ b/templates/author-post-meta-box.php
@@ -1,1 +1,4 @@
-<div class="fork-actions">    <a href="<?php echo admin_url( "?fork={$post->ID}" ); ?>" class="button button-primary create-new-fork-button"><?php _e( 'Create New Branch', 'post-forking' ); ?></a>     <div class="clear"></div></div>
+<div class="fork-actions">
+    <a href="<?php echo wp_nonce_url( admin_url( "?fork={$post->ID}" ), 'post-forking-fork_' . $post->ID ); ?>" class="button button-primary create-new-fork-button"><?php _e( 'Create New Branch', 'post-forking' ); ?></a>
+    <div class="clear"></div>
+</div>

--- a/templates/post-meta-box.php
+++ b/templates/post-meta-box.php
@@ -1,5 +1,5 @@
 <?php if ( $fork = $this->user_has_fork( $post->ID ) ) { ?>
 	<a href="<?php echo admin_url( "post.php?post=$fork&action=edit" ); ?>"><?php _e( 'View Fork', 'post-forking' ); ?></a>
 <?php } else { ?>
-	<a href="<?php echo admin_url( "?fork={$post->ID}" ); ?>" class="button button-primary"><?php _e( 'Fork', 'post-forking' ); ?></a>
+	<a href="<?php echo wp_nonce_url( admin_url( "?fork={$post->ID}" ), 'post-forking-fork_' . $post->ID ); ?>" class="button button-primary"><?php _e( 'Fork', 'post-forking' ); ?></a>
 <?php }


### PR DESCRIPTION
Stop people creating forks with naughty stuff in them and getting a user with higher privileges to merge them back in.
