### PR TITLE
Handle merge action

### DIFF
--- a/includes/merge.php
+++ b/includes/merge.php
@@ -49,6 +49,10 @@ class Fork_Merge {
 			'post_content' => $this->get_merged( $fork ),
 		);
 
+		// Note: $merge_author = id of user who's doing the merge
+	    $merge_author = wp_get_current_user()->ID;
+    	do_action( 'merge', $fork, $merge_author );
+    	
 		return wp_update_post( $update );
 
 	}


### PR DESCRIPTION
**Add merge hook** so that we can fire actions on `merge`.

**On the other hand**, the tests are failing because of an undefined method:

`Call to undefined method WP_Test_Post_Forking_Branches::assertCount()`  
