### PR TITLE
Fork_Merge->merge() returns post ID, not post object.

### DIFF
--- a/includes/merge.php
+++ b/includes/merge.php
@@ -235,7 +235,7 @@ class Fork_Merge {
 
 		$post = $this->merge( $post->ID );
 		$fork_update = array(
-			'ID' => $post->ID,
+			'ID' => $post,
 			'post_status' => 'merged',
 		);
 		wp_update_post( $fork_update );


### PR DESCRIPTION
Fork_Merge->merge() returns the value from wp_update_post(), which is an integer (the post ID), not a post object.

This was causing warnings such as

> PHP Notice:  Trying to get property of non-object in /wp-content/plugins/post-forking/includes/merge.php on line 238
