### PR TITLE
Admin Body Classes getting cleared

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -235,9 +235,9 @@ class Fork_Admin {
 	 * Add admin body class for the forks list table view
 	 */
 	function remove_add_new_list_table( $classes ) {
-		if ( 'edit-fork' == get_current_screen()->id )
+		if ( 'edit-fork' == get_current_screen()->id ) {
 			$classes .= ' fork-list';
-			
+		}
 		return $classes;
 	}
 

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -236,7 +236,9 @@ class Fork_Admin {
 	 */
 	function remove_add_new_list_table( $classes ) {
 		if ( 'edit-fork' == get_current_screen()->id )
-			return $classes .= ' fork-list';
+			$classes .= ' fork-list';
+			
+		return $classes;
 	}
 
 	/**


### PR DESCRIPTION
This update makes sure the filter on admin_body_class returns the $classes whether we're adding anything to them or not. Currently, nothing gets returned to the filter except on the "edit-fork" screen, which causes any other plugin's classes to be cleared unless they hook in at priority 11 or later
