### PR TITLE
Deprecate repository

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,7 @@
 # Post Forking #
 
+> **⚠️ DEPRECATED** - This project is no longer actively maintained. For collaborative WordPress content editing, please consider using the WordPress Gutenberg editor's collaboration features or other modern alternatives.
+
 [![Build Status](https://travis-ci.org/post-forking/post-forking.png)](https://travis-ci.org/post-forking/post-forking) [![Coverage Status](https://coveralls.io/repos/post-forking/post-forking/badge.png)](https://coveralls.io/r/post-forking/post-forking)
 
 WordPress Post Forking allows users to "fork" or create an alternate version of content to foster a more collaborative approach to WordPress content curation.


### PR DESCRIPTION
## Summary
This WordPress plugin is no longer actively maintained. The last commit was March 2014. The functionality it provided has been superseded by modern WordPress features, particularly the Gutenberg editor's built-in collaboration capabilities. Users should migrate to these native WordPress solutions for collaborative content editing.

- Add deprecation warning to README

## Test plan
- [ ] Verify deprecation notice appears prominently at the top of the README

## Additional steps
1. Go to the repository's [Settings](https://github.com/post-forking/post-forking/settings) tab
2. Scroll down to the **Danger Zone** section
3. Click **Archive** this repository
4. Confirm the action

This will:

* Make the repository read-only (no new issues, PRs, or commits)
* Add a yellow "Archived" banner at the top
* Stop Dependabot alerts
* Keep all existing content accessible